### PR TITLE
Swingの変動範囲を変更

### DIFF
--- a/main.py
+++ b/main.py
@@ -60,7 +60,7 @@ class investio(commands.Bot):
                     cursor.execute("UPDATE stocks SET price = price + ? WHERE name = ?", (random.randint(-250, 500), brand))
                 elif brand == "Swing":
                     stock_price = cursor.execute("SELECT price FROM stocks WHERE name = ?", (brand,)).fetchone()[0]
-                    cursor.execute("UPDATE stocks SET price = price + ? WHERE name = ?", (random.randint(int(stock_price * -0.5), int(stock_price * 0.5)), brand)) 
+                    cursor.execute("UPDATE stocks SET price = price + ? WHERE name = ?", (random.randint(int(stock_price /2), int(stock_price * 2)), brand)) 
                 if cursor.execute("SELECT price FROM stocks WHERE name = ?", (brand,)).fetchone()[0] < 100:
                     cursor.execute("UPDATE stocks SET price = 100 WHERE name = ?", (brand,))
             self.database.commit()


### PR DESCRIPTION
This pull request includes a modification to the `fluctuation` method in the `main.py` file to adjust the price update logic for the "Swing" brand. 

* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L63-R63): Changed the price fluctuation range for the "Swing" brand from a range based on 50% of the current stock price to a range between half and double the current stock price.